### PR TITLE
Fix build with gcc15

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,10 @@
+  * alloc.h, buffer.c, buffer.h, buffer_get.c, buffer_put.c, buffer_write.c,
+    byte.h, check-socklog-unix.c, pathexec_env.c, select.h1, select.h2,
+    sig.c, sig.h, sig_catch.c, socklog-check.c, socklog-check.dist,
+    socklog.c, tryto.c, tryto.dist, uncat.c, uncat.dist, wait.h: fix build
+    with gcc15: in C23 f() means f(void), consequently signal handler
+    functions now are f(int), alloc_free() and byte_zero() parameters need
+    casts, buffer_unixwrite() removes "const" from parameter.
   * tryto.c: don't report failure if the final try of prog succeeds (thx
     Andras Korn).
   * doc/index.html: remove reference to mailing list misc@list.smarden.org.

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -3,8 +3,8 @@
 #ifndef ALLOC_H
 #define ALLOC_H
 
-extern /*@null@*//*@out@*/char *alloc();
-extern void alloc_free();
-extern int alloc_re();
+extern /*@null@*//*@out@*/char *alloc(unsigned int);
+extern void alloc_free(char *);
+extern int alloc_re(char **,unsigned int,unsigned int);
 
 #endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2,7 +2,7 @@
 
 #include "buffer.h"
 
-void buffer_init(buffer *s,int (*op)(),int fd,char *buf,unsigned int len)
+void buffer_init(buffer *s,int (*op)(int,char *,unsigned int),int fd,char *buf,unsigned int len)
 {
   s->x = buf;
   s->fd = fd;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -8,14 +8,14 @@ typedef struct buffer {
   unsigned int p;
   unsigned int n;
   int fd;
-  int (*op)();
+  int (*op)(int,char *,unsigned int);
 } buffer;
 
 #define BUFFER_INIT(op,fd,buf,len) { (buf), 0, (len), (fd), (op) }
 #define BUFFER_INSIZE 8192
 #define BUFFER_OUTSIZE 8192
 
-extern void buffer_init(buffer *,int (*)(),int,char *,unsigned int);
+extern void buffer_init(buffer *,int (*)(int,char *,unsigned int),int,char *,unsigned int);
 
 extern int buffer_flush(buffer *);
 extern int buffer_put(buffer *,const char *,unsigned int);
@@ -50,7 +50,7 @@ extern void buffer_seek(buffer *,unsigned int);
 extern int buffer_copy(buffer *,buffer *);
 
 extern int buffer_unixread(int,char *,unsigned int);
-extern int buffer_unixwrite(int,const char *,unsigned int);
+extern int buffer_unixwrite(int,char *,unsigned int);
 
 extern buffer *buffer_0;
 extern buffer *buffer_0small;

--- a/src/buffer_get.c
+++ b/src/buffer_get.c
@@ -4,7 +4,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int oneread(int (*op)(),int fd,char *buf,unsigned int len)
+static int oneread(int (*op)(int,char *,unsigned int),int fd,char *buf,unsigned int len)
 {
   int r;
 

--- a/src/buffer_put.c
+++ b/src/buffer_put.c
@@ -5,7 +5,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int allwrite(int (*op)(),int fd,const char *buf,unsigned int len)
+static int allwrite(int (*op)(int,char *,unsigned int),int fd,const char *buf,unsigned int len)
 {
   int w;
 

--- a/src/buffer_write.c
+++ b/src/buffer_write.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include "buffer.h"
 
-int buffer_unixwrite(int fd,const char *buf,unsigned int len)
+int buffer_unixwrite(int fd,char *buf,unsigned int len)
 {
   return write(fd,buf,len);
 }

--- a/src/byte.h
+++ b/src/byte.h
@@ -3,12 +3,12 @@
 #ifndef BYTE_H
 #define BYTE_H
 
-extern unsigned int byte_chr();
-extern unsigned int byte_rchr();
-extern void byte_copy();
-extern void byte_copyr();
-extern int byte_diff();
-extern void byte_zero();
+extern unsigned int byte_chr(char *,unsigned int,int);
+extern unsigned int byte_rchr(char *,unsigned int,int);
+extern void byte_copy(char *,unsigned int,char *);
+extern void byte_copyr(char *,unsigned int,char *);
+extern int byte_diff(char *,unsigned int,char *);
+extern void byte_zero(char *,unsigned int);
 
 #define byte_equal(s,n,t) (!byte_diff((s),(n),(t)))
 

--- a/src/check-socklog-unix.c
+++ b/src/check-socklog-unix.c
@@ -14,7 +14,7 @@ struct sockaddr_un sa;
 int main() {
   s =socket(AF_UNIX, SOCK_DGRAM, 0);
   if (s == -1) strerr_die1sys(111, "fatal: unable to create socket: ");
-  byte_zero(&sa, sizeof(sa));
+  byte_zero((char *)&sa, sizeof(sa));
   sa.sun_family =AF_UNIX;
   strcpy(sa.sun_path, "socklog.check.socket");
   if (connect(s, (struct sockaddr *) &sa, sizeof(sa)) == -1)

--- a/src/pathexec_env.c
+++ b/src/pathexec_env.c
@@ -65,5 +65,5 @@ void pathexec(char *const *argv)
   e[elen] = 0;
 
   pathexec_run(*argv,argv,e);
-  alloc_free(e);
+  alloc_free((char *)e);
 }

--- a/src/select.h1
+++ b/src/select.h1
@@ -7,6 +7,6 @@
 
 #include <sys/types.h>
 #include <sys/time.h>
-extern int select();
+extern int select(int,fd_set *,fd_set *,fd_set *,struct timeval *);
 
 #endif

--- a/src/select.h2
+++ b/src/select.h2
@@ -8,6 +8,6 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/select.h>
-extern int select();
+extern int select(int,fd_set *,fd_set *,fd_set *,struct timeval *);
 
 #endif

--- a/src/sig.c
+++ b/src/sig.c
@@ -11,5 +11,5 @@ int sig_int = SIGINT;
 int sig_pipe = SIGPIPE;
 int sig_term = SIGTERM;
 
-void (*sig_defaulthandler)() = SIG_DFL;
-void (*sig_ignorehandler)() = SIG_IGN;
+void (*sig_defaulthandler)(int) = SIG_DFL;
+void (*sig_ignorehandler)(int) = SIG_IGN;

--- a/src/sig.h
+++ b/src/sig.h
@@ -11,10 +11,10 @@ extern int sig_int;
 extern int sig_pipe;
 extern int sig_term;
 
-extern void (*sig_defaulthandler)();
-extern void (*sig_ignorehandler)();
+extern void (*sig_defaulthandler)(int);
+extern void (*sig_ignorehandler)(int);
 
-extern void sig_catch(int,void (*)());
+extern void sig_catch(int,void (*)(int));
 #define sig_ignore(s) (sig_catch((s),sig_ignorehandler))
 #define sig_uncatch(s) (sig_catch((s),sig_defaulthandler))
 

--- a/src/sig_catch.c
+++ b/src/sig_catch.c
@@ -4,7 +4,7 @@
 #include "sig.h"
 #include "hassgact.h"
 
-void sig_catch(int sig,void (*f)())
+void sig_catch(int sig,void (*f)(int))
 {
 #ifdef HASSIGACTION
   struct sigaction sa;

--- a/src/socklog-check.c
+++ b/src/socklog-check.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   }
   if ((s =socket(AF_UNIX, SOCK_DGRAM, 0)) == -1)
     strerr_die4sys(111, FATAL, "unable to create socket: ", address, ": ");
-  byte_zero(&sa, sizeof(sa));
+  byte_zero((char *)&sa, sizeof(sa));
   sa.sun_family =AF_UNIX;
   strncpy(sa.sun_path, address, sizeof(sa.sun_path));
   if (connect(s, (struct sockaddr *)&sa, sizeof(sa)) == -1) {

--- a/src/socklog-check.dist
+++ b/src/socklog-check.dist
@@ -1,4 +1,4 @@
-$Id: 564e285f617e05c82bb6ecf91727d10ecb8eeae1 $
+$Id: 1846f398826fdcf04b22c5f175298d41f0f679b1 $
 usage: socklog-check [-v] [unix [address]]
 
 1

--- a/src/socklog.c
+++ b/src/socklog.c
@@ -64,7 +64,7 @@ unsigned int lograw =0;
 unsigned int noumask =0;
 
 int flag_exitasap = 0;
-void sig_term_catch(void) {
+void sig_term_catch(int) {
   flag_exitasap = 1;
 }
 
@@ -166,7 +166,7 @@ int socket_unix (const char* f) {
   
   if ((s =socket(AF_UNIX, SOCK_DGRAM, 0)) == -1)
     strerr_die2sys(111, FATAL, "socket(): ");
-  byte_zero(&sa, sizeof(sa));
+  byte_zero((char *)&sa, sizeof(sa));
   sa.sun_family =AF_UNIX;
   strncpy(sa.sun_path, f, sizeof(sa.sun_path));
   unlink(f);
@@ -183,7 +183,7 @@ int socket_inet (const char* ip, const char* port) {
   unsigned long p;
   struct sockaddr_in sa;
   
-  byte_zero(&sa, sizeof(sa));
+  byte_zero((char *)&sa, sizeof(sa));
   if (ip[0] == '0') {
     sa.sin_addr.s_addr =INADDR_ANY;
   } else {

--- a/src/tryto.c
+++ b/src/tryto.c
@@ -27,7 +27,7 @@ const char *progname;
 int selfpipe[2];
 int try =0;
 
-void sig_child_handler(void) {
+void sig_child_handler(int) {
   try++;
   write(selfpipe[1], "", 1);
 }

--- a/src/tryto.dist
+++ b/src/tryto.dist
@@ -1,7 +1,7 @@
 usage: tryto [-vp] [-t seconds] [-k kseconds] [-n tries] prog
 
 1
-$Id: 80c28c19b0bd7c033e1052adfee4ce1bb647c9bf $
+$Id: b0dd878062ddb08a864c5b863cc221d3cca2600f $
 
 usage: tryto [-vp] [-t seconds] [-k kseconds] [-n tries] prog
 

--- a/src/uncat.c
+++ b/src/uncat.c
@@ -24,7 +24,7 @@
 const char *progname;
 int exitasap =0;
 
-void exit_asap() {
+void exit_asap(int) {
   exitasap =1;
 }
 

--- a/src/uncat.dist
+++ b/src/uncat.dist
@@ -1,7 +1,7 @@
 usage: uncat [-vo] [-t timeout] [-s size] prog
 
 1
-$Id: b7787391481949f7223e326decd0a46e4fd444e4 $
+$Id: 42845bab9fe12a6fd768b9931a18c382c4a2e83b $
 
 usage: uncat [-vo] [-t timeout] [-s size] prog
 

--- a/src/wait.h
+++ b/src/wait.h
@@ -3,8 +3,8 @@
 #ifndef WAIT_H
 #define WAIT_H
 
-extern int wait_pid();
-extern int wait_nohang();
+extern int wait_pid(int *,int);
+extern int wait_nohang(int *);
 extern int wait_stop();
 extern int wait_stopnohang();
 


### PR DESCRIPTION
In C23 f() means f(void), consequently signal handler functions now are f(int), alloc_free() and byte_zero() parameters need casts, buffer_unixwrite() removes "const" from parameter.

https://gcc.gnu.org/gcc-15/changes.html